### PR TITLE
feat: adding custom stub

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,7 @@ module.exports = function (grunt) {
   grunt.loadTasks('build/tasks');
 
   var langs;
+  var wrapper = !!grunt.option('wrapper');
   if (grunt.option('lang')) {
     langs = (grunt.option('lang') || '').split(/[,;]/g).map(function (lang) {
       lang = lang.trim();
@@ -85,11 +86,11 @@ module.exports = function (grunt) {
         files: langs.map(function (lang, i) {
           return {
             src: [
-              'lib/intro.stub',
+              wrapper ? 'lib/custom/intro.stub' : 'lib/intro.stub',
               '<%= concat.engine.coreFiles %>',
               // include rules / checks / commons
               '<%= configure.rules.files[' + i + '].dest.auto %>',
-              'lib/outro.stub'
+              wrapper ? 'lib/custom/outro.stub' : 'lib/outro.stub'
             ],
             dest: 'axe' + lang + '.js'
           };
@@ -127,7 +128,8 @@ module.exports = function (grunt) {
         entry: 'lib/commons/aria/index.js',
         destFile: 'doc/aria-supported.md',
         options: {
-          langs: langs
+          langs: langs,
+          wrapper: wrapper
         },
         listType: 'unsupported' // Possible values for listType: 'supported', 'unsupported', 'all'
       }

--- a/build/tasks/aria-supported.js
+++ b/build/tasks/aria-supported.js
@@ -16,7 +16,8 @@ module.exports = function (grunt) {
        * hence cannot be required at the top of the file.
        */
       const done = this.async();
-      const { langs } = this.options();
+      const { langs, wrapper } = this.options();
+      if (wrapper) return true;
       const fileNameSuffix = langs && langs.length > 0 ? `${langs[0]}` : '';
       const axe = require(`../../axe${fileNameSuffix}`);
       const listType = this.data.listType.toLowerCase();

--- a/lib/custom/intro.stub
+++ b/lib/custom/intro.stub
@@ -1,0 +1,15 @@
+/*! axe v<%= pkg.version %>
+ * Copyright (c) 2015 - <%= grunt.template.today("yyyy") %> Deque Systems, Inc.
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+const createAxe = () => (function axeFunction (window) {
+  // A window reference is required to access the axe object in a "global".
+  var global = window;
+  var document = window.document;

--- a/lib/custom/outro.stub
+++ b/lib/custom/outro.stub
@@ -1,0 +1,2 @@
+
+}( typeof window === 'object' ? window : this ));

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "develop": "grunt dev --force",
     "api-docs": "jsdoc --configure .jsdoc.json",
     "build": "grunt",
+    "build:wrapper": "grunt --wrapper=true",
     "eslint": "eslint --color --format stylish '{lib,test,build,doc}/**/*.js' 'Gruntfile.js'",
     "test": "npm run test:tsc && run-s \"test:unit:* -- {@}\" --",
     "test:tsc": "tsc",


### PR DESCRIPTION
DOMForge Core requires changes in axe-core. By default when axe-core is injected in webpage an anonymous function is executed and axe get initialised on global window object, this is not the preferred in DOMForge.

Closes https://browserstack.atlassian.net/browse/AXE-342
