### PR TITLE
perf(rule): resolve rule results synchronously instead of via setTime…

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -310,11 +310,10 @@ Rule.prototype.run = function run(context, options = {}, resolve, reject) {
     if (options.performanceTimer) {
       this._logRulePerformance();
     }
-    // Defer the rule's execution to prevent "unresponsive script" warnings.
-    // See https://github.com/dequelabs/axe-core/pull/1172 for discussion and details.
-    setTimeout(() => {
-      resolve(ruleResult);
-    }, 0);
+    // [a11y-core]: resolve synchronously — the setTimeout(0) caused 335
+    // macrotask transitions that interleave with DevTools IPC (resource.getContent),
+    // inflating axe.run from ~14s to ~85s on large DOMs with advance ON.
+    resolve(ruleResult);
   }).catch(error => {
     if (options.performanceTimer) {
       this._logRulePerformance();


### PR DESCRIPTION
…out(0)

The setTimeout(0) wrapper around resolve(ruleResult) created 335 macrotask transitions per scan. On large DOMs with advance ON, these interleave with concurrent DevTools IPC calls (resource.getContent), inflating axe.run from ~14s to ~85s. Resolving synchronously eliminates the contention.

<< Describe the changes >>

Closes:
