### PR TITLE
feat(rule): gate sync rule-result resolution behind runTypeASync flag

### DIFF
--- a/lib/core/base/rule.js
+++ b/lib/core/base/rule.js
@@ -310,11 +310,39 @@ Rule.prototype.run = function run(context, options = {}, resolve, reject) {
     if (options.performanceTimer) {
       this._logRulePerformance();
     }
-    // Defer the rule's execution to prevent "unresponsive script" warnings.
-    // See https://github.com/dequelabs/axe-core/pull/1172 for discussion and details.
-    setTimeout(() => {
+    // [a11y-core]: runTypeASync ON resolves synchronously; OFF keeps the
+    // deferred setTimeout(0) resolve (Deque #1172) and records yield delay.
+    if (cache.get('runTypeASync')) {
       resolve(ruleResult);
-    }, 0);
+    } else {
+      let scheduledAt;
+      try {
+        scheduledAt = window.performance.now();
+      } catch {
+        scheduledAt = undefined;
+      }
+      setTimeout(() => {
+        try {
+          if (scheduledAt !== undefined) {
+            const yieldDelay = window.performance.now() - scheduledAt;
+            const yieldStats = axe._typeASyncYield || {
+              totalMs: 0,
+              count: 0,
+              maxMs: 0
+            };
+            yieldStats.totalMs += yieldDelay;
+            yieldStats.count += 1;
+            if (yieldDelay > yieldStats.maxMs) {
+              yieldStats.maxMs = yieldDelay;
+            }
+            axe._typeASyncYield = yieldStats;
+          }
+        } catch {
+          // ignore instrumentation failures
+        }
+        resolve(ruleResult);
+      }, 0);
+    }
   }).catch(error => {
     if (options.performanceTimer) {
       this._logRulePerformance();


### PR DESCRIPTION
## What

Gates per-rule result resolution on a new `runTypeASync` flag (set into `axe._cache` by `a11y-engine-core` from the `a11yCoreConfig.runTypeASync` config field):

- **Flag ON** → `resolve(ruleResult)` synchronously.
- **Flag OFF (default)** → original `setTimeout(0)` defer (Deque #1172), unchanged behaviour, **plus** lightweight yield-latency instrumentation.

## Why

The `setTimeout(0)` wrapper around `resolve(ruleResult)` creates one macrotask transition per rule (~335). On large DOMs with **advance ON**, these interleave with concurrent DevTools IPC (`resource.getContent`), inflating the per-rule resolve from ~8ms to ~180ms and `axe.run` from ~14s to ~85s (Savvas Realize investigation). Resolving synchronously eliminates the contention.

We are shipping the fix **behind a flag, default OFF**, and want to measure which other customers exhibit the same pathology before enabling it for them.

## Instrumentation (OFF path only)

Accumulates the schedule-to-fire delay of each resolve yield onto `axe._typeASyncYield` `{ totalMs, count, maxMs }`. `a11y-engine-core` reads this back after `axe.run` and surfaces it in Type A telemetry. `totalMs` ≈ the wall-clock the async resolve costs = the exact time the flag would recover.

## Cost / safety

- Adds **no new macrotask** — only times the `setTimeout` that already existed on `main`. Event-loop behaviour on the OFF path is byte-for-byte identical to today.
- ~2 `performance.now()` + a few arithmetic ops per rule ≈ **~1ms per scan**; scales with rule count, not DOM size.
- No per-rule allocations (three scalars on one object, reset per run) — no GC pressure.
- Fully wrapped in try/catch: instrumentation can never break rule resolution.

## Tagging

All changes carry `// [a11y-core]:` per submodule convention.

## Test plan

- [x] `build_axe.sh` compiles clean; `runTypeASync` + `_typeASyncYield` present in built `axe.js`.
- [ ] Flag ON: rules resolve synchronously, `type_a_sync_yield_count` reports 0.
- [ ] Flag OFF: `type_a_sync_yield_total_ms` populated on a large advance-ON scan.

Paired with a11y-engine PR (flag extraction + telemetry surfacing + submodule bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)