### PR TITLE
chore: harden .npmrc for supply-chain audit (AXE-3444)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,10 @@ jobs:
       - browser-tools-job
       # install ACT rules
       # install first as for some reason installing a single package
-      # also re-installs all repo dependencies as well
-      - run: npm install w3c/wcag-act-rules#main
+      # also re-installs all repo dependencies as well. .npmrc sets
+      # ignore-scripts=true (AXE-3444); the full re-install would otherwise skip
+      # native postinstalls (e.g. esbuild), so allow scripts for this trusted install.
+      - run: npm install w3c/wcag-act-rules#main --ignore-scripts=false
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
       - run: npm run test:act
@@ -222,8 +224,10 @@ jobs:
       - browser-tools-job
       # install ARIA practices
       # install first as for some reason installing a single package
-      # also re-installs all repo dependencies as well
-      - run: npm install w3c/aria-practices#main
+      # also re-installs all repo dependencies as well. .npmrc sets
+      # ignore-scripts=true (AXE-3444); the full re-install would otherwise skip
+      # native postinstalls (e.g. esbuild), so allow scripts for this trusted install.
+      - run: npm install w3c/aria-practices#main --ignore-scripts=false
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
       - run: npm run test:apg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ jobs:
       - browser-tools-job
       - <<: *set_npm_auth
       - run: npm ci
+      # .npmrc sets ignore-scripts=true (supply-chain hardening, AXE-3444), which
+      # skips esbuild's postinstall that fetches its native bundler binary. Rebuild
+      # it explicitly so the cached node_modules carries the binary to build_unix.
+      - run: npm rebuild esbuild --ignore-scripts=false --foreground-scripts
       - run: npx browser-driver-manager install chromedriver --verbose
       - save_cache:
           key: v9-cache-unix-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,6 @@ jobs:
       - browser-tools-job
       - <<: *set_npm_auth
       - run: npm ci
-      # .npmrc sets ignore-scripts=true (supply-chain hardening, AXE-3444), which
-      # skips esbuild's postinstall that fetches its native bundler binary. Rebuild
-      # it explicitly so the cached node_modules carries the binary to build_unix.
       - run: npm rebuild esbuild --ignore-scripts=false --foreground-scripts
       - run: npx browser-driver-manager install chromedriver --verbose
       - save_cache:
@@ -206,10 +203,8 @@ jobs:
       - browser-tools-job
       # install ACT rules
       # install first as for some reason installing a single package
-      # also re-installs all repo dependencies as well. .npmrc sets
-      # ignore-scripts=true (AXE-3444); the full re-install would otherwise skip
-      # native postinstalls (e.g. esbuild), so allow scripts for this trusted install.
-      - run: npm install w3c/wcag-act-rules#main --ignore-scripts=false
+      # also re-installs all repo dependencies as well
+      - run: npm install w3c/wcag-act-rules#main
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
       - run: npm run test:act
@@ -224,10 +219,8 @@ jobs:
       - browser-tools-job
       # install ARIA practices
       # install first as for some reason installing a single package
-      # also re-installs all repo dependencies as well. .npmrc sets
-      # ignore-scripts=true (AXE-3444); the full re-install would otherwise skip
-      # native postinstalls (e.g. esbuild), so allow scripts for this trusted install.
-      - run: npm install w3c/aria-practices#main --ignore-scripts=false
+      # also re-installs all repo dependencies as well
+      - run: npm install w3c/aria-practices#main
       - run: npx browser-driver-manager install chromedriver --verbose
       - <<: *restore_build
       - run: npm run test:apg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
       - run: npm ci
+      # .npmrc sets ignore-scripts=true (supply-chain hardening, AXE-3444), which
+      # skips esbuild's postinstall that fetches its native bundler binary. Rebuild
+      # it explicitly so `npm run build` (grunt -> esbuild) can run.
+      - run: npm rebuild esbuild --ignore-scripts=false --foreground-scripts
       - run: npm run prepare
       - run: npm run build
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
       - run: npm ci
-      # .npmrc sets ignore-scripts=true (supply-chain hardening, AXE-3444), which
-      # skips esbuild's postinstall that fetches its native bundler binary. Rebuild
-      # it explicitly so `npm run build` (grunt -> esbuild) can run.
       - run: npm rebuild esbuild --ignore-scripts=false --foreground-scripts
       - run: npm run prepare
       - run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,10 @@
 registry=https://registry.npmjs.org
+
+# Supply-chain hardening directives (AXE-3444 / SC-12282) — linted weekly by Enigma.
+# Do NOT add tokens or secrets here; this repo installs from the public registry.
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+audit-level=high
+engine-strict=true
+legacy-peer-deps=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
 registry=https://registry.npmjs.org
 
-# Supply-chain hardening directives (AXE-3444 / SC-12282) — linted weekly by Enigma.
+# Supply-chain hardening directives (AXE-3444). Public repo: access is left
+# unset (access=restricted applies to private repos only).
 # Do NOT add tokens or secrets here; this repo installs from the public registry.
 ignore-scripts=true
 strict-ssl=true

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -34,6 +34,7 @@ Axe 3.0 supports open Shadow DOM: see our virtual DOM APIs and test utilities fo
 1. You must have Node.js version 22 or higher installed.
    If you have [nvm](https://github.com/nvm-sh/nvm) installed, simply do `nvm use` in the root of this repository.
 1. Install npm development dependencies. In the root folder of your axe-core repository, run `npm install`
+1. The committed `.npmrc` sets `ignore-scripts=true` for supply-chain hardening, so dependency lifecycle scripts do not run during install. After installing, run `npm run prepare` (applies dependency patches and installs git hooks) and `npm rebuild esbuild --ignore-scripts=false` (fetches the esbuild bundler binary) before building.
 
 ### Building axe.js
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "standard-version": {
     "scripts": {
-      "postbump": "npm ci && npm run sri-update && git add doc/rule-descriptions.md"
+      "postbump": "npm ci && npm rebuild esbuild --ignore-scripts=false --foreground-scripts && npm run sri-update && git add doc/rule-descriptions.md"
     },
     "skip": {
       "tag": true


### PR DESCRIPTION
## What & why

The weekly Enigma supply-chain audit ([SC-12282](https://browserstack.atlassian.net/browse/SC-12282)) flagged `browserstack/a11y-engine-axe-core` with status **misconfigured** ([AXE-3444](https://browserstack.atlassian.net/browse/AXE-3444)): the committed root `.npmrc` existed but was missing every required hardening directive.

This adds the six flagged directives so the next weekly audit passes.

## Changes

### `.npmrc` — the audit fix
Added the six required directives:

| Directive | Purpose |
|---|---|
| `ignore-scripts=true` | blocks malicious dependency lifecycle scripts |
| `strict-ssl=true` | enforces TLS to the registry |
| `save-exact=true` | pins exact versions on install |
| `audit-level=high` | fail on high+ advisories |
| `engine-strict=true` | refuse incompatible Node engines |
| `legacy-peer-deps=false` | preserve npm 7+ peer-dep resolution |

**`access=restricted` is intentionally omitted** — it applies to private repos only, and this repository is public. (The audit's missing-directives list did not include `access`.)

No tokens or secrets are added: this repo installs from the public npm registry and has no scoped/authenticated registry in `.npmrc`.

### `.circleci/config.yml` — keep the build green under `ignore-scripts`
`ignore-scripts=true` suppresses dependency lifecycle scripts during `npm ci`, including **esbuild's `postinstall`** that downloads its native bundler binary. Without it, `build_unix` → `npm run build` (grunt → esbuild) would fail.

`dependencies_unix` is the only job that runs `npm ci` and it caches `node_modules` for every downstream job, so a single explicit rebuild there fixes the whole pipeline:

```
- run: npm rebuild esbuild --ignore-scripts=false --foreground-scripts
```

Two things deliberately **not** changed:
- **chromedriver** — its npm install script is also skipped, but CI fetches the driver via `browser-driver-manager` (and the `browser-tools` orb), so it's unaffected.
- **patch-package** — `build_unix` runs `npm run prepare` *explicitly*, and `ignore-scripts` only suppresses pre/post hooks *around* an explicit `npm run`, not the invoked script itself. So `husky && npm run patch` still applies `patches/colorjs.io+0.4.3.patch`.

### `doc/developer-guide.md` — local-dev note
Documents the post-install steps now required locally (`npm run prepare` + `npm rebuild esbuild --ignore-scripts=false`) before building.

## Reviewer note
`engine-strict=true` now makes `npm ci` refuse packages whose declared engines don't match the runner's Node. CI uses Node 22 (`cimg/node:22.16`); if a transitive dependency ever declares an incompatible range, install will fail loudly — that's the intended behavior, and any such dep is a separate fix.

## Test plan
- [ ] CI `dependencies_unix` → `build_unix` is green (esbuild binary present after rebuild)
- [ ] Browser test jobs green (chromedriver via browser-driver-manager)
- [ ] Next weekly Enigma audit reports the repo as compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SC-12282]: https://browserstack.atlassian.net/browse/SC-12282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AXE-3444]: https://browserstack.atlassian.net/browse/AXE-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ