### PR TITLE
AXE-3659 R0: pin fork behaviors ahead of the staged 4.12.1 upgrade (tests only)

### DIFF
--- a/test/checks/color/color-contrast-fork-pinning.js
+++ b/test/checks/color/color-contrast-fork-pinning.js
@@ -1,0 +1,80 @@
+describe('color-contrast (BrowserStack fork pinning)', () => {
+  // AXE-3659 — pins fork-only behavior in lib/checks/color/color-contrast-evaluate.js
+  // that has zero upstream coverage, so the 4.12.1 merge (and the deferred colorParse
+  // graft) cannot silently drop it:
+  //   1. reviewPayload.visualHelperData  (// a11y-rule-color-contrast) — bulk-NR payload
+  //      consumed by dom-forge-core violation-helper + ip-protection jobAIColorContrast.
+  //   2. whole-body try/catch + addCheckError  (// a11y-color-contrast) — AXE-2707
+  //      resilience: a check-internal error must not crash the Type-A run.
+  const { html, checkSetup, MockCheckContext, getCheckEvaluate } =
+    axe.testUtils;
+  const fixture = document.getElementById('fixture');
+  const checkContext = MockCheckContext();
+
+  afterEach(() => {
+    fixture.innerHTML = '';
+    checkContext.reset();
+    axe._tree = undefined;
+    delete window.a11yEngine;
+  });
+
+  it('emits reviewPayload.visualHelperData (fgColor/bgColor/isLargeText/textContent)', () => {
+    const contrastEvaluate = getCheckEvaluate('color-contrast', {
+      verifyMessage: false
+    });
+    const params = checkSetup(html`
+      <div style="background-color: #fff; color: #111; font-size: 12pt;">
+        <span id="target">Sample text content</span>
+      </div>
+    `);
+    contrastEvaluate.apply(checkContext, params);
+
+    const data = checkContext._data || {};
+    const vhd = data.reviewPayload && data.reviewPayload.visualHelperData;
+    assert.isObject(vhd, 'reviewPayload.visualHelperData must be present');
+    assert.property(vhd, 'fgColor');
+    assert.property(vhd, 'bgColor');
+    assert.isBoolean(vhd.isLargeText);
+    assert.equal(vhd.textContent, 'Sample text content');
+  });
+
+  it('truncates reviewPayload.textContent to at most 100 chars', () => {
+    const contrastEvaluate = getCheckEvaluate('color-contrast', {
+      verifyMessage: false
+    });
+    const long = new Array(60).fill('word').join(' '); // ~299 chars, word-spaced
+    const params = checkSetup(
+      '<div style="background-color:#fff;color:#111;font-size:12pt;">' +
+        '<span id="target">' +
+        long +
+        '</span></div>'
+    );
+    contrastEvaluate.apply(checkContext, params);
+    const tc = checkContext._data.reviewPayload.visualHelperData.textContent;
+    assert.isAtMost(tc.length, 100);
+  });
+
+  it('catches an internal error: messageKey "Check error", addCheckError, returns undefined', () => {
+    const addCheckError = sinon.spy();
+    window.a11yEngine = { errorHandler: { addCheckError } };
+    const params = checkSetup(
+      '<div id="target" style="color:#000;background:#fff;">x</div>'
+    );
+    const rawEvaluate = axe._audit.checks['color-contrast'].evaluate;
+    // options === undefined -> the top-of-body destructure throws INSIDE the try
+    const result = rawEvaluate.call(
+      checkContext,
+      params[0],
+      undefined,
+      params[2]
+    );
+
+    assert.isUndefined(result);
+    assert.equal(checkContext._data.messageKey, 'Check error');
+    assert.isTrue(
+      addCheckError.calledOnce,
+      'addCheckError called exactly once'
+    );
+    assert.instanceOf(addCheckError.firstCall.args[1], Error);
+  });
+});

--- a/test/checks/label/label-content-name-mismatch-fork-pinning.js
+++ b/test/checks/label/label-content-name-mismatch-fork-pinning.js
@@ -1,0 +1,59 @@
+describe('label-content-name-mismatch (BrowserStack fork pinning)', () => {
+  // AXE-3659 — pins the fork's reimplementation in
+  // lib/checks/label/label-content-name-mismatch-evaluate.js (all // a11y-rule-* tagged).
+  // The 4.12.1 merge DECLINES upstream's subtreeText->visibleVirtual switch (Tier-1 #1)
+  // because that switch would drop the fork's ignoreNativeTextAlternative flag and its
+  // NLP. These tests fail if upstream's simpler literal-includes logic were adopted:
+  //   1. wink-porter2 stemming (inflected visible text still matches the name)
+  //   2. whitespace/case-insensitive matching (curateString strips whitespace)
+  //   3. reviewPayload.visualHelperData.accessibleName on a genuine mismatch
+  // The subtreeText({ ignoreNativeTextAlternative: true }) call is the fork evaluate
+  // path these cases exercise end-to-end.
+  const { checkSetup, MockCheckContext, getCheckEvaluate } = axe.testUtils;
+  const fixture = document.getElementById('fixture');
+  const checkContext = MockCheckContext();
+  const evaluate = getCheckEvaluate('label-content-name-mismatch', {
+    verifyMessage: false
+  });
+
+  afterEach(() => {
+    fixture.innerHTML = '';
+    checkContext.reset();
+    axe._tree = undefined;
+  });
+
+  it('passes when visible text is an inflected (stemmed) form of the accessible name', () => {
+    // "saving change" stems to "save chang", matching "save changes"; upstream's
+    // literal includes-check would report a mismatch here.
+    const params = checkSetup(
+      '<button id="target" aria-label="save changes">Saving change</button>'
+    );
+    assert.isTrue(evaluate.apply(checkContext, params));
+  });
+
+  it('matches ignoring whitespace and case (fork curateString strips whitespace)', () => {
+    // "Log In" (name) vs "login" (content) match only because the fork strips
+    // whitespace before comparing; upstream's whitespace-sensitive compare would not.
+    const params = checkSetup(
+      '<button id="target" aria-label="Log In">login</button>'
+    );
+    assert.isTrue(evaluate.apply(checkContext, params));
+  });
+
+  it('reports a genuine mismatch and emits reviewPayload.visualHelperData.accessibleName', () => {
+    const params = checkSetup(
+      '<button id="target" aria-label="Cancel">Submit</button>'
+    );
+    const result = evaluate.apply(checkContext, params);
+    assert.isFalse(result, 'unrelated visible text vs name is a mismatch');
+    const vhd =
+      checkContext._data &&
+      checkContext._data.reviewPayload &&
+      checkContext._data.reviewPayload.visualHelperData;
+    assert.isObject(
+      vhd,
+      'reviewPayload.visualHelperData must be present on mismatch'
+    );
+    assert.equal(vhd.accessibleName, 'cancel');
+  });
+});

--- a/test/commons/dom/is-in-text-block-fork-pinning.js
+++ b/test/commons/dom/is-in-text-block-fork-pinning.js
@@ -1,0 +1,58 @@
+describe('dom.isInTextBlock (BrowserStack fork pinning)', () => {
+  // AXE-3659 — pins the fork-only // a11y-critical STYLE-skip in
+  // lib/commons/dom/is-in-text-block.js: walkDomNode must not descend into <style>
+  // elements, so CSS text inside a <style> is NOT counted as surrounding text.
+  // Zero upstream coverage. In task 4 this skip must be re-applied into upstream's
+  // relocated walkDomNode, so this test guards the behavior across that refactor.
+  const { html, fixtureSetup } = axe.testUtils;
+  const isInTextBlock = axe.commons.dom.isInTextBlock;
+  const fixture = document.getElementById('fixture');
+
+  afterEach(() => {
+    fixture.innerHTML = '';
+    axe.teardown();
+    axe._tree = undefined;
+  });
+
+  it('does not count CSS text inside a <style> element as surrounding text', () => {
+    fixtureSetup(html`
+      <div id="block">
+        <style>
+          #block a {
+            color: red;
+            background: blue;
+            padding: 20px;
+            margin: 10px;
+          }
+        </style>
+        <a href="#" id="target">link</a>
+      </div>
+    `);
+    const link = document.getElementById('target');
+    // Only content besides the link is the <style>; with the STYLE-skip its CSS
+    // text is excluded, leaving no surrounding text.
+    assert.isFalse(
+      isInTextBlock(link, { noLengthCompare: true }),
+      'CSS text inside <style> must not register as surrounding text'
+    );
+  });
+
+  it('still detects genuine surrounding text alongside a <style> element', () => {
+    fixtureSetup(html`
+      <div id="block2">
+        <style>
+          #block2 a {
+            color: red;
+          }
+        </style>
+        Some real visible paragraph text here
+        <a href="#" id="target">link</a>
+      </div>
+    `);
+    const link = document.getElementById('target');
+    assert.isTrue(
+      isInTextBlock(link, { noLengthCompare: true }),
+      'genuine surrounding text is still counted (skip is not over-broad)'
+    );
+  });
+});

--- a/test/core/utils/dq-element-fork-pinning.js
+++ b/test/core/utils/dq-element-fork-pinning.js
@@ -1,0 +1,57 @@
+describe('DqElement (BrowserStack fork pinning)', () => {
+  // AXE-3659 — pins fork-only behavior in lib/core/utils/dq-element.js (all // a11y-*
+  // tagged) with zero upstream coverage:
+  //   1. htmlHash fingerprint on toJSON()            (// [a11y-core])
+  //   2. data-percy-* attribute stripping in source   (// a11y-critical)
+  //   3. targetFormat==='ancestry' selector branch    (// a11y-critical, axe._cache)
+  //   4. runTypeAOpt source branch via getSourceOpt    (// a11y-critical, axe._cache)
+  // These consumer-critical fields (htmlHash, source, ancestry selector) are asserted
+  // in the Tech Spec §Consumer dependencies as load-bearing for ip-protection/dom-forge.
+  const DqElement = axe.utils.DqElement;
+  const { fixtureSetup, queryFixture } = axe.testUtils;
+  const fixture = document.getElementById('fixture');
+
+  afterEach(() => {
+    axe._cache.set('runTypeAOpt', undefined);
+    axe._cache.set('targetFormat', undefined);
+    axe.reset();
+  });
+
+  it('toJSON() includes an htmlHash that fingerprints the element outerHTML', () => {
+    fixtureSetup(
+      '<div class="a">X</div><div class="a">X</div><div class="a">Y</div>'
+    );
+    const h0 = new DqElement(fixture.children[0]).toJSON().htmlHash;
+    const h1 = new DqElement(fixture.children[1]).toJSON().htmlHash;
+    const h2 = new DqElement(fixture.children[2]).toJSON().htmlHash;
+    assert.isString(h0);
+    assert.isNotEmpty(h0);
+    assert.equal(h0, h1, 'identical outerHTML -> identical htmlHash');
+    assert.notEqual(h0, h2, 'different outerHTML -> different htmlHash');
+  });
+
+  it('strips data-percy-* attributes from source, keeps real attributes', () => {
+    const vNode = queryFixture(
+      '<div id="target" data-percy-injected="true" class="keep">Hi</div>'
+    );
+    const source = new DqElement(vNode).source;
+    assert.notInclude(source, 'data-percy');
+    assert.include(source, 'class="keep"');
+  });
+
+  it('targetFormat==="ancestry" -> selector is [getAncestry(element)]', () => {
+    const vNode = queryFixture('<div id="target">Hi</div>');
+    // set AFTER setup so fixtureSetup/axe.setup cannot clear it before construction
+    axe._cache.set('targetFormat', 'ancestry');
+    const dq = new DqElement(vNode);
+    assert.deepEqual(dq.selector, [axe.utils.getAncestry(vNode.actualNode)]);
+  });
+
+  it('runTypeAOpt -> source generated via getSourceOpt (open tag only for parents)', () => {
+    const vNode = queryFixture('<div id="target"><span>child</span></div>');
+    axe._cache.set('runTypeAOpt', true);
+    const dq = new DqElement(vNode);
+    // getSourceOpt: element has children -> emits the open tag with attributes only
+    assert.equal(dq.source, '<div id="target">');
+  });
+});

--- a/test/core/utils/get-ancestry-fork-pinning.js
+++ b/test/core/utils/get-ancestry-fork-pinning.js
@@ -1,0 +1,58 @@
+describe('axe.utils.getAncestry (BrowserStack fork pinning)', () => {
+  // AXE-3659 — pins the fork-only // a11y-critical behavior in
+  // lib/core/utils/get-ancestry.js: when computing :nth-child for a DIRECT child of
+  // <body>, Percy-injected siblings (data-percy-injected) are ignored, so ancestry
+  // indexes match the un-instrumented page. Zero upstream coverage.
+  //
+  // Method: measure a body child's ancestry, then insert a data-percy-injected sibling
+  // immediately before it and re-measure. The fork skips the percy node, so the index
+  // must be UNCHANGED. (Without the skip, the index would increment by one.)
+  const getAncestry = axe.utils.getAncestry;
+
+  const removeForkPins = () => {
+    Array.prototype.slice
+      .call(document.body.querySelectorAll('[data-fork-pin]'))
+      .forEach(el => el.remove());
+  };
+
+  afterEach(() => {
+    axe.teardown();
+    removeForkPins();
+  });
+
+  it('data-percy-injected body siblings do not shift a body child :nth-child', () => {
+    removeForkPins();
+    const sib = document.createElement('div');
+    sib.setAttribute('data-fork-pin', '');
+    const target = document.createElement('div');
+    target.id = 'fork-pin-target';
+    target.setAttribute('data-fork-pin', '');
+    document.body.appendChild(sib);
+    document.body.appendChild(target);
+
+    axe.setup(document.documentElement);
+    const before = getAncestry(target);
+    axe.teardown(); // clears the ancestry/selector cache between measurements
+
+    const percy = document.createElement('div');
+    percy.setAttribute('data-percy-injected', 'true');
+    percy.setAttribute('data-fork-pin', '');
+    document.body.insertBefore(percy, target); // directly before target
+
+    axe.setup(document.documentElement);
+    const after = getAncestry(target);
+    axe.teardown();
+
+    removeForkPins();
+    assert.include(
+      String(before),
+      ':nth-child',
+      'sanity: a body child ancestry uses :nth-child'
+    );
+    assert.deepEqual(
+      after,
+      before,
+      'a Percy-injected sibling must be ignored when indexing :nth-child'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**R0 of the AXE-3659 incremental upgrade plan** — tests only, zero behavior change.

Adds 13 pinning tests (5 files) characterizing fork-only behaviors that previously had **zero coverage**, so the upcoming staged axe-core 4.11→4.12.1 merges (R1: v4.11.1 → engine 6.5.0, R2: v4.11.4 → 6.6.0, R3: v4.12.1 → 7.0.0) cannot silently regress them:

- **color-contrast**: `reviewPayload.visualHelperData` (+100-char truncation) and the whole-body try/catch → `addCheckError` (AXE-2707 resilience)
- **dq-element**: `htmlHash` fingerprint, `data-percy-*` source stripping, `runTypeAOpt`/`targetFormat=ancestry` source & selector branches
- **get-ancestry**: Percy `data-percy-injected` `:nth-child` skip
- **is-in-text-block**: `<style>`-element skip
- **label-content-name-mismatch**: wink-porter2 stemming, whitespace/case-insensitive matching, mismatch `reviewPayload`

All tests are classic-style karma (no ESM), runnable isolated via `npm run test:unit -- testFiles=...` and in the full suite.

## Why land this before any merge

These are the regression guard for every subsequent slice. Landing them first means the guard exists *before* any upstream content moves (plan: `docs/tech-specs/AXE-3659-incremental-release-plan.md` in the a11y-engine repo; the one-shot merge PR #249 remains as the end-state reference).

## Validation

- Cherry-picked from the reviewed merge branch (`7532cb51`); pinned lib files verified byte-identical between this base (`c2feddeb`) and the merge branch.
- `npm ci` (current main lockfile, esbuild 0.28.1) + `npm run build` from main's lib (Node 22): green, `axe.min.js` 623.69 KB.
- **13/13 SUCCESS against the main-built bundle.**

Ref: AXE-3659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
