### PR TITLE
chore(deps): security bumps — postcss, shell-quote (AXE-3900/AXE-3901)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10133,9 +10133,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -10143,6 +10143,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -11242,9 +11243,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -11260,9 +11261,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12204,10 +12206,11 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -21235,9 +21238,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "peer": true
     },
@@ -21418,7 +21421,7 @@
         "minimatch": "^3.1.3",
         "pidtree": "^0.3.0",
         "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
+        "shell-quote": "1.10.0",
         "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
@@ -22069,13 +22072,13 @@
       }
     },
     "postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -22794,9 +22797,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true
     },
     "shellwords": {

--- a/package.json
+++ b/package.json
@@ -212,6 +212,8 @@
     "brace-expansion@5": "5.0.7",
     "js-yaml@3": "3.15.0",
     "js-yaml@4": "4.3.0",
-    "linkify-it": "5.0.2"
+    "linkify-it": "5.0.2",
+    "postcss": "8.5.23",
+    "shell-quote": "1.10.0"
   }
 }


### PR DESCRIPTION
Pins two vulnerable transitive **dev** dependencies to patched versions via `package.json` overrides, so the fix survives lockfile regeneration instead of living only in the lock.

| Ticket | Package | Before | After | Advisory |
|---|---|---|---|---|
| [AXE-3900](https://browserstack.atlassian.net/browse/AXE-3900) | postcss | 8.5.6 | **8.5.23** | [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) — arbitrary file read via attacker-controlled `sourceMappingURL` |
| [AXE-3901](https://browserstack.atlassian.net/browse/AXE-3901) | shell-quote | 1.8.4 | **1.10.0** | [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv) — quadratic-complexity DoS in `parse()` |

First-patched are 8.5.12 and 1.9.0; both go to latest-in-major, matching the versions already used elsewhere in the monorepo (`mini-percy-renderer` is already on shell-quote 1.10.0).

### No runtime exposure

axe-core declares **no** `dependencies` — everything is `devDependencies`, so neither package ships in the published bundle:

- `postcss` ← `@csstools/css-syntax-patches-for-csstree` ← `cssstyle` ← `jsdom` (test-time DOM)
- `shell-quote` ← `npm-run-all` (build scripts)

Neither advisory's attack path is reachable here: we don't run untrusted CSS through PostCSS, and we don't pass untrusted strings to `shell-quote.parse()`. This is hygiene to clear the Dependabot alerts, not an incident.

### Notes for review

- Lockfile deliberately kept at **v2** (`npm install --package-lock-only --lockfile-version=2`); npm 10+ would otherwise migrate to v3 and produce a ~12k-line diff.
- `nanoid` 3.3.11 → 3.3.16 comes along as postcss's own dependency — expected, not a separate bump.
- Diff is scoped to exactly these three packages; no unrelated version drift.
- Impact tag is recorded in the commit message (`[a11y-critical]`) rather than a code comment, since both changed files are JSON. Same convention as #266.

Supersedes Dependabot #269 (postcss → 8.5.22) and #271 (shell-quote → 1.10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AXE-3900]: https://browserstack.atlassian.net/browse/AXE-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AXE-3901]: https://browserstack.atlassian.net/browse/AXE-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ