### PR TITLE
fix(scrollable-region-focusable): keep description browser-agnostic

### DIFF
--- a/lib/rules/scrollable-region-focusable.json
+++ b/lib/rules/scrollable-region-focusable.json
@@ -18,7 +18,7 @@
   ],
   "actIds": ["0ssw9k"],
   "metadata": {
-    "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
+    "description": "Ensure elements that have scrollable content are accessible by keyboard",
     "help": "Scrollable region must have keyboard access"
   },
   "all": [],

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -420,7 +420,7 @@
       "help": "scope attribute should be used correctly"
     },
     "scrollable-region-focusable": {
-      "description": "Ensure elements that have scrollable content are accessible by keyboard in Safari",
+      "description": "Ensure elements that have scrollable content are accessible by keyboard",
       "help": "Scrollable region must have keyboard access"
     },
     "select-name": {


### PR DESCRIPTION
Reverts the Safari-specific wording added in upstream #4995. Rule fires across browsers, description should remain generic.