### PR TITLE
test(ci): DO NOT MERGE — control experiment for test_node (20) failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,5 @@ Thanks to Marat Dulin for his [css-selector-parser](https://www.npmjs.com/packag
 ## Licenses
 
 Axe-core is distributed under the [Mozilla Public License, version 2.0](LICENSE). It comes bundled with several dependencies which are distributed under their own terms. (See [LICENSE-3RD-PARTY.txt](LICENSE-3RD-PARTY.txt))
+
+<!-- CI control experiment: documentation-only no-op to observe the test_node matrix on an untouched dependency tree. Do not merge; delete this line and the branch once CI has reported. -->


### PR DESCRIPTION
## ⚠️ Do not merge — CI control experiment

This PR exists **only** to test a hypothesis about CI. Close it once the checks have reported.

### What's in it

One HTML comment appended to `README.md`. Nothing else:

```
 README.md | 2 ++
 1 file changed, 2 insertions(+)
```

`package.json` and `package-lock.json` are **byte-identical to `main`** — the dependency tree is completely untouched.

### The hypothesis

[#277](https://github.com/browserstack/a11y-engine-axe-core/pull/277) (postcss + shell-quote overrides) fails `test_node (20)`. The claim is that this failure is **environmental and unrelated to that diff**:

`test/node/node.js` installs **unpinned `jsdom@latest`** at test runtime, out of band, ignoring the lockfile. jsdom then dropped Node 20:

- `jsdom@30.0.0` published 2026-07-27, `30.0.1` on 2026-07-29
- `jsdom@30.0.1` declares `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`

So on the Node 20 matrix leg the install fails with `EBADENGINE` and the following `require('jsdom')` throws `MODULE_NOT_FOUND`. The other legs report `CANCELLED` purely from matrix fail-fast, which makes the blast radius look wider than it is.

Supporting timeline — the same check passed on PRs whose runs **predate** the jsdom 30 releases:

| PR | `test_node (20)` | ran at |
|---|---|---|
| [#271](https://github.com/browserstack/a11y-engine-axe-core/pull/271) shell-quote (dependabot) | SUCCESS | 2026-07-24 |
| [#269](https://github.com/browserstack/a11y-engine-axe-core/pull/269) postcss (dependabot) | SUCCESS | 2026-07-24 |
| [#277](https://github.com/browserstack/a11y-engine-axe-core/pull/277) | FAILURE | 2026-07-31 |

### How to read the result

- **If this PR also fails `test_node (20)`** → confirmed. The break is dated, not diff-related, and #277 is clear to merge on that basis. Every PR opened against `main` from now on will fail the same way until the unpinned `jsdom@latest` is addressed.
- **If this PR passes** → the hypothesis is wrong and #277's failure needs to be investigated as a real regression from those overrides.

### Follow-up either way

The unpinned `jsdom@latest` in `test/node/node.js` should be pinned, or Node 20 dropped from the matrix. Note the repo's own `devDependencies` pin is `jsdom@^27.0.0`, which works fine on Node 20 — only the runtime `@latest` install is the problem. That needs its own ticket; it is deliberately not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
