### PR TITLE
chore: bump fork version to 4.12.1 to match adopted upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-core",
-  "version": "4.11.0",
+  "version": "4.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-core",
-      "version": "4.11.0",
+      "version": "4.12.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@axe-core/webdriverjs": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axe-core",
   "description": "Accessibility engine for automated Web UI testing",
-  "version": "4.11.0",
+  "version": "4.12.1",
   "license": "MPL-2.0",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Bumps `package.json` / `package-lock.json` version `4.11.0` → `4.12.1`.

